### PR TITLE
Added new query params to pz-logger:

### DIFF
--- a/lib/client.go
+++ b/lib/client.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"time"
 
@@ -57,9 +58,21 @@ func NewClient(sys *piazza.SystemConfig) (*Client, error) {
 	return service, nil
 }
 
-func (c *Client) GetFromMessages(format elasticsearch.QueryFormat) ([]Message, error) {
+func (c *Client) GetFromMessages(format elasticsearch.QueryFormat, params map[string]string) ([]Message, error) {
 
 	url := fmt.Sprintf("%s/messages?size=%d&from=%d&key=%s&order=%t", c.url, format.Size, format.From, format.Key, format.Order)
+	
+	var names = []string {"before", "after", "service", "contains"}
+	
+	for _, name := range names {
+		if value, ok := params[name]; ok {
+    		//do something here
+			url = fmt.Sprintf("%s&%s=%s", url, name, value)
+		}	
+	}
+	
+	log.Printf("%s\n", url)
+	
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, err

--- a/lib/common.go
+++ b/lib/common.go
@@ -39,7 +39,7 @@ type IClient interface {
 	GetFromAdminStats() (*LoggerAdminStats, error)
 
 	// read support
-	GetFromMessages(format elasticsearch.QueryFormat) ([]Message, error)
+	GetFromMessages(format elasticsearch.QueryFormat, params map[string]string) ([]Message, error)
 
 	// write support
 	LogMessage(mssg *Message) error

--- a/lib/mock_client.go
+++ b/lib/mock_client.go
@@ -40,7 +40,7 @@ func NewMockClient(sys *piazza.SystemConfig) (IClient, error) {
 	return service, nil
 }
 
-func (logger *MockClient) GetFromMessages(format elasticsearch.QueryFormat) ([]Message, error) {
+func (logger *MockClient) GetFromMessages(format elasticsearch.QueryFormat, params map[string]string) ([]Message, error) {
 	size := format.Size
 	from := format.From
 

--- a/lib/server.go
+++ b/lib/server.go
@@ -16,6 +16,7 @@ package lib
 
 import (
 	"encoding/json"
+_	"fmt"
 	"log"
 	"net/http"
 	"strconv"
@@ -163,11 +164,22 @@ func handleGetMessages(c *gin.Context) {
 	var err error
 
 	format := elasticsearch.GetFormatParams(c, 10, 0, "stamp", elasticsearch.SortDescending)
+	filterParams := parseFilterParams(c)
 
 	//log.Printf("size %d, from %d, key %s, format %v",
 	//	format.Size, format.From, format.Key, format.Order)
 
-	searchResult, err := logData.esIndex.FilterByMatchAll(schema, format)
+	log.Printf("filterParams: %v\n", filterParams)
+
+	var searchResult *elasticsearch.SearchResult
+		
+	if len(filterParams) == 0 {
+		searchResult, err = logData.esIndex.FilterByMatchAll(schema, format)		
+	} else  {
+		var jsonString = createQueryDslAsString(format, filterParams)	
+		searchResult, err = logData.esIndex.SearchByJSON(schema, jsonString)
+	}
+	
 	if err != nil {
 		c.String(http.StatusBadRequest, "query failed: %s", err)
 		return
@@ -224,3 +236,114 @@ func CreateHandlers(sys *piazza.SystemConfig, esi elasticsearch.IIndex) http.Han
 
 	return router
 }
+
+func parseFilterParams(c *gin.Context) map[string]interface{} {
+	
+	var filterParams = map[string]interface{}{}
+		
+	before, beforeExists := c.GetQuery("before")
+
+	if beforeExists && before != "" {
+		num, err := strconv.Atoi(before)
+		if err == nil {
+			filterParams["before"] =  num					
+		}
+	}	
+							
+	after, afterExists := c.GetQuery("after")
+	
+	if afterExists && after != "" {
+		num, err := strconv.Atoi(after)
+		if err == nil {
+			filterParams["after"] =  num					
+		}
+	}
+
+	service, serviceExists := c.GetQuery("service")
+
+	if serviceExists && service != "" {
+		filterParams["service"] = service		
+	}
+	
+	contains, containsExists := c.GetQuery("contains")
+	
+	if containsExists && contains != "" {
+		filterParams["contains"] = contains
+	}
+
+	return filterParams
+}
+
+func createQueryDslAsString(
+    format elasticsearch.QueryFormat, 
+    params map[string]interface{},
+) string {    
+    // fmt.Printf("%d\n", len(params))
+    
+    must := []map[string]interface{}{}
+    
+    
+    if params["service"] != nil {
+        must = append(must, map[string]interface{} {
+            "match": map[string]interface{} {
+                "service": params["service"],    
+            },    
+        })        
+    }
+    
+    if params["contains"] != nil {
+        must = append(must, map[string]interface{} {
+            "multi_match": map[string]interface{} {
+                "query": params["contains"],
+                "fields": []string {"address", "message", "service", "serverity"},     
+            },    
+        })                
+    }
+    
+    if params["after"] != nil || params["before"] != nil {
+        rangeParams := map[string]int {}
+
+        if params["after"] != nil {
+            rangeParams["gte"] = params["after"].(int)
+        }        
+        
+        if params["before"] != nil {
+            rangeParams["lte"] = params["before"].(int)                
+        }        
+
+        must = append(must, map[string]interface{} {
+            "range": map[string]interface{} {
+                "stamp": rangeParams,    
+            },    
+        })        
+    }
+    
+    dsl := map[string]interface{} {
+        "query": map[string]interface{} {
+            "filtered": map[string]interface{} {
+                "query": map[string]interface{} {
+                    "bool": map[string]interface{} {
+                        "must": must,
+                    },   
+                },
+            },    
+        },
+        "size": format.Size,
+        "from": format.From,             
+    }
+	
+	var sortOrder string
+	
+	if format.Order {
+		sortOrder = "desc"		
+	} else {
+		sortOrder = "asc"
+	}
+	
+	dsl["sort"] = map[string]string {
+		format.Key: sortOrder,                
+	}  
+    
+    output, _ := json.Marshal(dsl)
+    return string(output)    
+}    


### PR DESCRIPTION
-- service: filter by the name of the service (i.e.  Dispatcher,   Gateway,  etc)
-- contains: filter by whether the specified phrase exists anywhere in the message
-- before:  show only messages that occured before  (inclusive)  the specified timestamp
-- after:  show only messages that occured after (inclusive)  the specified timestamp
